### PR TITLE
remove message ui dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ env:
     - MESSAGE_NOTIFY_MODULE='message_notify'
     - MESSAGE_NOTIFY_REPO='https://github.com/Gizra/message_notify.git'
     - MESSAGE_NOTIFY_VERSION='8.x-1.x'
-    - MESSAGE_UI_MODULE='message_ui'
-    - MESSAGE_UI_REPO='https://github.com/mccrodp/message_ui.git'
-    - MESSAGE_UI_VERSION='8.x-1.x'
     - MODULE_NAME='message_private'
     - MODULE_TEST_GROUP='Message Private'
     - DRUPAL_REPO='git://drupalcode.org/project/drupal.git'
@@ -62,7 +59,6 @@ install:
   - cd drupal/modules
   - git clone --branch $MESSAGE_VERSION $MESSAGE_REPO
   - git clone --branch $MESSAGE_NOTIFY_VERSION $MESSAGE_NOTIFY_REPO
-  - git clone --branch $MESSAGE_UI_VERSION $MESSAGE_UI_REPO
   - cd ../
 
 before_script:

--- a/message_private.info.yml
+++ b/message_private.info.yml
@@ -8,4 +8,3 @@ dependencies:
   - views
   - message
   - message_notify
-  - message_ui


### PR DESCRIPTION
There is no need to make message_ui a dependency.  What if we want to disable UI module on production?