### PR TITLE
Fix exception when saving a new reply

### DIFF
--- a/message_private.module
+++ b/message_private.module
@@ -222,15 +222,9 @@ function message_private_message_insert(\Drupal\message\MessageInterface $messag
     $mail = array();
     $users = $message->get('field_message_private_to_user');
 
-    if (!empty($users)) {
-      // Make users an array if user ref field is configured to 1 entry.
-      $users = is_array($users) ? $users : array($users);
+    if (!$users->isEmpty()) {
       foreach ($users as $user) {
-        $notify = $user->get('field_private_message_notify');
-        if (!empty($notify) && is_array($notify)) {
-          // Get the 1st value of the array as there is only 1 possible item.
-          $notify = array_shift($notify);
-        }
+        $notify = $user->entity->get('field_message_private_usr_notify')->value;
         // If the user has set field for notifications, add their email.
         if (isset($notify['value']) && $notify['value']) {
           $mail[] = $user->mail;
@@ -258,7 +252,7 @@ function message_private_form_user_profile_form_alter(&$form, FormStateInterface
   // rewrite this call manually.
   if (!\Drupal::currentUser()->hasPermission('bypass private message access control')
     && !\Drupal::config('message_private.settings')->get('email_notify')) {
-    $form['field_private_message_notify']['#access'] = FALSE;
+    $form['field_message_private_usr_notify']['#access'] = FALSE;
   }
 }
 


### PR DESCRIPTION
Fixes #18 

When saving the private message I'm getting:

```
The website encountered an unexpected error. Please try again later.</br></br><em class="placeholder">Drupal\Core\Entity\EntityStorageException</em>: Unable to get a value with a non-numeric delta in a list. in <em class="placeholder">Drupal\Core\Entity\Sql\SqlContentEntityStorage-&gt;save()</em> (line <em class="placeholder">783</em> of <em class="placeholder">core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php</em>). <pre class="backtrace">message_private_message_insert(Object)
call_user_func_array(&#039;message_private_message_insert&#039;, Array) (Line: 403)
Drupal\Core\Extension\ModuleHandler-&gt;invokeAll(&#039;message_insert&#039;, Array) (Line: 204)
Drupal\Core\Entity\EntityStorageBase-&gt;invokeHook(&#039;insert&#039;, Object) (Line: 756)
Drupal\Core\Entity\ContentEntityStorageBase-&gt;invokeHook(&#039;insert&#039;, Object) (Line: 507)
Drupal\Core\Entity\EntityStorageBase-&gt;doPostSave(Object, ) (Line: 641)
Drupal\Core\Entity\ContentEntityStorageBase-&gt;doPostSave(Object, ) (Line: 432)
...
```