### PR TITLE
Support drupal/message_ui #45

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
     - MESSAGE_NOTIFY_MODULE='message_notify'
     - MESSAGE_NOTIFY_REPO='https://github.com/Gizra/message_notify.git'
     - MESSAGE_NOTIFY_VERSION='8.x-1.x'
+    - MESSAGE_UI_MODULE='message_ui'
+    - MESSAGE_UI_REPO='https://github.com/mccrodp/message_ui.git'
+    - MESSAGE_UI_VERSION='8.x-1.x'
     - MODULE_NAME='message_private'
     - MODULE_TEST_GROUP='Message Private'
     - DRUPAL_REPO='git://drupalcode.org/project/drupal.git'
@@ -59,6 +62,7 @@ install:
   - cd drupal/modules
   - git clone --branch $MESSAGE_VERSION $MESSAGE_REPO
   - git clone --branch $MESSAGE_NOTIFY_VERSION $MESSAGE_NOTIFY_REPO
+  - git clone --branch $MESSAGE_UI_VERSION $MESSAGE_UI_REPO
   - cd ../
 
 before_script:

--- a/config/optional/message.template.private_message.yml
+++ b/config/optional/message.template.private_message.yml
@@ -7,3 +7,6 @@ description: 'Private Message message template.'
 text:
   - "<p>Private Message -</p>\r\n"
 settings: {  }
+third_party_settings:
+  message_ui:
+    enabled: true

--- a/message_private.info.yml
+++ b/message_private.info.yml
@@ -8,3 +8,5 @@ dependencies:
   - views
   - message
   - message_notify
+  - message_ui
+  


### PR DESCRIPTION
This is blocked on https://github.com/RoySegall/message_ui/pull/45. 

It just ensures support for https://github.com/RoySegall/message_ui/pull/45